### PR TITLE
I've made some changes to the styling of locked premium sections, app…

### DIFF
--- a/src/components/auth/RegisterCoachForm.tsx
+++ b/src/components/auth/RegisterCoachForm.tsx
@@ -512,9 +512,16 @@ export default function RegisterCoachForm({ planId }: RegisterCoachFormProps) {
                     )}
                     </div>
                     {isFreeTier && (
-                      <div className="text-center p-4 mt-2 border border-dashed border-gray-300 rounded-md bg-gray-50">
-                        <p className="text-sm text-gray-600 mb-2">Profile Picture is a Premium Feature.</p>
-                        <Button type="button" size="sm" onClick={handleUpgradeToPremium}>
+                      <div className="text-center p-4 mt-3 border border-custom-gold bg-light-gold-bg rounded-md">
+                        <Crown className="h-6 w-6 text-custom-gold mx-auto mb-2" />
+                        <p className="text-sm text-neutral-700 mb-3">Profile Picture is a Premium Feature.</p>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="border-custom-gold text-custom-gold hover:bg-custom-gold hover:text-white"
+                          onClick={handleUpgradeToPremium}
+                        >
                           Upgrade to Unlock
                         </Button>
                       </div>
@@ -534,9 +541,17 @@ export default function RegisterCoachForm({ planId }: RegisterCoachFormProps) {
               <Controller name="websiteUrl" control={control} render={({ field }) => <Input id="websiteUrl" type="url" placeholder="https://yourwebsite.com" {...field} className="text-base py-2.5" disabled={isFreeTier} />} />
               {errors.websiteUrl && <p className="text-sm text-destructive mt-1">{errors.websiteUrl.message}</p>}
               {isFreeTier && (
-                <div className="text-right mt-1">
-                  <Button type="button" size="sm" variant="link" className="text-primary hover:text-primary/80 p-0 h-auto" onClick={handleUpgradeToPremium}>
-                    Upgrade to Unlock
+                <div className="text-center p-3 mt-2 border border-custom-gold bg-light-gold-bg rounded-md">
+                  <Sparkles className="h-5 w-5 text-custom-gold mx-auto mb-1" />
+                  <p className="text-xs text-neutral-700 mb-2">Adding a Website URL is a Premium Feature.</p>
+                  <Button
+                    type="button"
+                    size="xs" /* Slightly smaller button for these individual field upgrades */
+                    variant="outline"
+                    className="border-custom-gold text-custom-gold hover:bg-custom-gold hover:text-white"
+                    onClick={handleUpgradeToPremium}
+                  >
+                    Upgrade
                   </Button>
                 </div>
               )}
@@ -546,9 +561,17 @@ export default function RegisterCoachForm({ planId }: RegisterCoachFormProps) {
               <Controller name="introVideoUrl" control={control} render={({ field }) => <Input id="introVideoUrl" type="url" placeholder="https://youtube.com/yourvideo" {...field} className="text-base py-2.5" disabled={isFreeTier} />} />
               {errors.introVideoUrl && <p className="text-sm text-destructive mt-1">{errors.introVideoUrl.message}</p>}
               {isFreeTier && (
-                <div className="text-right mt-1">
-                  <Button type="button" size="sm" variant="link" className="text-primary hover:text-primary/80 p-0 h-auto" onClick={handleUpgradeToPremium}>
-                    Upgrade to Unlock
+                <div className="text-center p-3 mt-2 border border-custom-gold bg-light-gold-bg rounded-md">
+                  <Sparkles className="h-5 w-5 text-custom-gold mx-auto mb-1" />
+                  <p className="text-xs text-neutral-700 mb-2">Adding an Intro Video is a Premium Feature.</p>
+                  <Button
+                    type="button"
+                    size="xs" /* Slightly smaller button */
+                    variant="outline"
+                    className="border-custom-gold text-custom-gold hover:bg-custom-gold hover:text-white"
+                    onClick={handleUpgradeToPremium}
+                  >
+                    Upgrade
                   </Button>
                 </div>
               )}
@@ -565,9 +588,16 @@ export default function RegisterCoachForm({ planId }: RegisterCoachFormProps) {
                 {errors.socialLinkUrl && <p className="text-sm text-destructive mt-1">{errors.socialLinkUrl.message}</p>}
               </div>
               {isFreeTier && (
-                <div className="md:col-span-2 text-center p-4 mt-2 border border-dashed border-gray-300 rounded-md bg-gray-50">
-                  <p className="text-sm text-gray-600 mb-2">Adding Social Media Links is a Premium Feature.</p>
-                  <Button type="button" size="sm" onClick={handleUpgradeToPremium}>
+                <div className="md:col-span-2 text-center p-4 mt-3 border border-custom-gold bg-light-gold-bg rounded-md">
+                  <LinkIcon className="h-6 w-6 text-custom-gold mx-auto mb-2" />
+                  <p className="text-sm text-neutral-700 mb-3">Adding Social Media Links is a Premium Feature.</p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="border-custom-gold text-custom-gold hover:bg-custom-gold hover:text-white"
+                    onClick={handleUpgradeToPremium}
+                  >
                     Upgrade to Unlock
                   </Button>
                 </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -43,6 +43,8 @@ export default {
   			border: 'hsl(var(--border))',
   			input: 'hsl(var(--input))',
   			ring: 'hsl(var(--ring))',
+        'custom-gold': '#FFD700', // A standard gold
+        'light-gold-bg': '#FFFBEA', // A very pale, light yellow/gold for backgrounds
   			chart: {
   				'1': 'hsl(var(--chart-1))',
   				'2': 'hsl(var(--chart-2))',


### PR DESCRIPTION
…lying a gold theme to enhance the visual indication of premium features and upgrade paths for you.

Here's what I did:

- I updated the configuration to include 'custom-gold' and 'light-gold-bg'.
- I restyled the 'Upgrade to Unlock' callout for the Profile Picture with a gold border and background, and added a Crown icon.
- I similarly restyled the callout for Social Media Links, incorporating a LinkIcon.
- I enhanced the Website URL and Intro Video URL upgrade prompts, transforming them from simple links into styled callout boxes with the gold theme and a Sparkles icon.
- Buttons within these callouts now also feature gold accents.

These changes are active when your account is on the free tier.