### PR TITLE
Fix: Ensure coach dashboard reflects premium status changes correctly

### DIFF
--- a/src/app/dashboard/coach/page.tsx
+++ b/src/app/dashboard/coach/page.tsx
@@ -18,7 +18,7 @@ interface AppUser extends User {
 }
 
 export default function CoachDashboardPage() {
-  const { user: authUser, loading } = useAuth();
+  const { user: authUser, loading, refreshUserProfile } = useAuth(); // Added refreshUserProfile
   const user = authUser as AppUser | null; // Cast to AppUser
   const { toast } = useToast();
   const [coachName, setCoachName] = useState("Coach");
@@ -26,6 +26,18 @@ export default function CoachDashboardPage() {
   const [newMessages, setNewMessages] = useState(0);
   const [isLoadingStats, setIsLoadingStats] = useState(true);
   const [isUpgrading, setIsUpgrading] = useState(false);
+
+  // useEffect to refresh user profile on mount and when user.id/loading changes
+  useEffect(() => {
+    if (!loading && user?.id) {
+      console.log("[CoachDashboardPage] Attempting to refresh user profile.");
+      refreshUserProfile().catch(err => {
+        console.error("[CoachDashboardPage] Error refreshing user profile:", err);
+        // Optionally show a toast to the user if refresh fails
+        // toast({ title: "Profile Sync Error", description: "Could not sync your latest profile data.", variant: "destructive" });
+      });
+    }
+  }, [user?.id, loading, refreshUserProfile, toast]); // Added toast to dependencies as it's used in the catch block if uncommented
 
   useEffect(() => {
     if (user && user.role === 'coach') {


### PR DESCRIPTION
The "Unlock Premium Features" card on your coach dashboard (`/dashboard/coach`) was sometimes displayed even after an admin upgraded a coach to premium. This was because your subscription tier in the auth context was not being updated in real-time after the Firestore change.

This commit addresses the issue by:
1. Modifying `src/lib/auth.tsx`:
    - Ensures `subscriptionTier` from Firestore is correctly included in the `user` object within the `AuthContext` for coaches.
    - Adds a `refreshUserProfile` function to the `AuthContext` to allow explicit refreshing of your profile data (including `subscriptionTier`) from Firestore.

2. Modifying `src/app/dashboard/coach/page.tsx`:
    - Calls the new `refreshUserProfile` function from `useAuth()` when the coach dashboard page loads. This ensures that the `subscriptionTier` is up-to-date, and the "Unlock Premium Features" card is displayed or hidden based on the latest data.