### PR TITLE
Revert: Remove coach dashboard refresh logic to restore stability

### DIFF
--- a/src/app/dashboard/coach/page.tsx
+++ b/src/app/dashboard/coach/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { FileText, MessageSquare, UserCircle, PlusCircle, BarChart3, Loader2, Star, ExternalLink } from "lucide-react";
 import { useAuth, type User } from "@/lib/auth"; // Assuming User type can be imported from auth
-import { useEffect, useState, useRef } from "react"; // Imported useRef
+import { useEffect, useState } from "react"; // Removed useRef
 import { getCoachBlogStats, getCoachUnreadMessageCount } from "@/lib/firestore";
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { loadStripe } from '@stripe/stripe-js';
@@ -18,30 +18,17 @@ interface AppUser extends User {
 }
 
 export default function CoachDashboardPage() {
-  const { user: authUser, loading, refreshUserProfile } = useAuth(); // Added refreshUserProfile
+  const { user: authUser, loading } = useAuth(); // Removed refreshUserProfile
   const user = authUser as AppUser | null; // Cast to AppUser
   const { toast } = useToast();
-  const hasRefreshedInitially = useRef(false); // Initialized ref
+  // const hasRefreshedInitially = useRef(false); // Removed ref
   const [coachName, setCoachName] = useState("Coach");
   const [blogStats, setBlogStats] = useState<{ pending: number, published: number }>({ pending: 0, published: 0 });
   const [newMessages, setNewMessages] = useState(0);
   const [isLoadingStats, setIsLoadingStats] = useState(true);
   const [isUpgrading, setIsUpgrading] = useState(false);
 
-  // useEffect to refresh user profile on initial mount
-  useEffect(() => {
-    if (!loading && user?.id && !hasRefreshedInitially.current) {
-      console.log("[CoachDashboardPage] Attempting initial user profile refresh.");
-      refreshUserProfile().then(() => {
-        console.log("[CoachDashboardPage] Initial user profile refresh successful.");
-        hasRefreshedInitially.current = true;
-      }).catch(err => {
-        console.error("[CoachDashboardPage] Error during initial user profile refresh:", err);
-        // Optionally show a toast to the user if refresh fails
-        // toast({ title: "Profile Sync Error", description: "Could not sync your latest profile data.", variant: "destructive" });
-      });
-    }
-  }, [user?.id, loading, refreshUserProfile]); // Dependency array updated
+  // Removed useEffect for refreshUserProfile
 
   useEffect(() => {
     if (user && user.role === 'coach') {


### PR DESCRIPTION
This commit reverts changes made in an attempt to dynamically update the coach's premium status visibility on the main coach dashboard (`/dashboard/coach`). These changes inadvertently introduced an infinite loading loop.

Reverted changes include:
- Removal of the `refreshUserProfile` function and its `useCallback` wrapper from `src/lib/auth.tsx`.
- Removal of the `useEffect` hook and associated `useRef` (`hasRefreshedInitially`) from `src/app/dashboard/coach/page.tsx` that was responsible for calling `refreshUserProfile`.

The coach dashboard will now rely on your subscription tier as loaded by the `AuthProvider` during initial authentication. This prioritizes dashboard stability.

The "Unlock Premium Features" card on `/dashboard/coach` may not immediately reflect changes made by an admin to a coach's tier during an active session until you log out and log back in. The profile edit page (`/dashboard/coach/profile`) should still correctly reflect the premium status due to its independent data fetch.