### PR TITLE
Refactor: Remove Performance Overview section from coach dashboard

### DIFF
--- a/src/app/dashboard/coach/page.tsx
+++ b/src/app/dashboard/coach/page.tsx
@@ -222,19 +222,7 @@ export default function CoachDashboardPage() {
       )}
 
       {/* Performance Overview Card - Stays after the (potentially moved) Upgrade card */}
-      <Card>
-        <CardHeader>
-            <CardTitle className="flex items-center"><BarChart3 className="mr-2 h-5 w-5 text-primary" />Performance Overview</CardTitle>
-            <CardDescription>Summary of your profile views and engagement. {isPremiumCoach && <span className="text-sm text-green-500">(Premium Analytics Unlocked)</span>}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isPremiumCoach ? (
-             <p className="text-muted-foreground">Display premium analytics here...</p>
-          ) : (
-            <p className="text-muted-foreground">Profile views, message rates, and blog engagement statistics will appear here. Upgrade to Premium for advanced analytics.</p>
-          )}
-        </CardContent>
-      </Card>
+      {/* Removed Performance Overview Card */}
     </div>
   );
 }


### PR DESCRIPTION
This commit removes the "Performance Overview" card entirely from the coach dashboard page (`src/app/dashboard/coach/page.tsx`).

This change was made at your request to simplify the coach dashboard interface for all coaches (free and premium).