### PR TITLE
Fix: Implement actual Firebase password reset email functionality

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -11,6 +11,8 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loader2, Mail, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { getAuth, sendPasswordResetEmail } from 'firebase/auth';
+// Assuming 'app' from '@/lib/firebase' is initialized globally and getAuth() works without it.
 
 const forgotPasswordSchema = z.object({
   email: z.string().email('Invalid email address.'),
@@ -28,14 +30,24 @@ export default function ForgotPasswordPage() {
 
   const onSubmit: SubmitHandler<ForgotPasswordFormData> = async (data) => {
     setIsLoading(true);
-    // Simulate API call for password reset
-    await new Promise(resolve => setTimeout(resolve, 1500));
-    setIsLoading(false);
-    setSubmitted(true);
-    toast({
-      title: "Password Reset Email Sent",
-      description: `If an account exists for ${data.email}, you will receive password reset instructions.`,
-    });
+    try {
+      const auth = getAuth();
+      await sendPasswordResetEmail(auth, data.email);
+      toast({
+        title: "Password Reset Email Sent",
+        description: `If an account exists for ${data.email}, you will receive password reset instructions. Please check your inbox (and spam folder).`,
+      });
+      setSubmitted(true);
+    } catch (error: any) {
+      console.error("Password reset error:", error);
+      toast({
+        title: "Error Sending Reset Email",
+        description: error.message || "An unexpected error occurred. Please ensure you are online and try again later.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (


### PR DESCRIPTION
The forgot password page was previously only simulating the sending of a password reset email using a timeout. This commit replaces the simulation with a proper call to Firebase Authentication's `sendPasswordResetEmail` function.

Changes in `src/app/forgot-password/page.tsx`:
- Imported `getAuth` and `sendPasswordResetEmail` from `firebase/auth`.
- Modified the `onSubmit` handler to:
  - Get the Firebase Auth instance.
  - Call `await sendPasswordResetEmail(auth, data.email)`.
  - Implement a try/catch/finally block for robust error handling and loading state management.
  - Display a success toast to you upon requesting the reset email (this message is shown whether the email exists or not, to prevent email enumeration).
  - Display an error toast if an unexpected issue occurs during the Firebase call (e.g., network error).

This change ensures that the application now correctly attempts to send a password reset email when requested by you.