### PR TITLE
feat: Implement testimonial management system

### DIFF
--- a/TESTING_STRATEGY.md
+++ b/TESTING_STRATEGY.md
@@ -1,0 +1,203 @@
+# Testimonial Functionality Testing Strategy
+
+This document outlines the test cases for the newly implemented testimonial functionality, covering API endpoints, frontend components, and the homepage display.
+
+## 1. API Endpoint Tests
+
+These tests should verify the behavior of the testimonial API routes. Tools like `supertest` (for Node.js/Express-like environments) or Next.js specific API route testing utilities (e.g., with `jest` or `vitest` and `node-mocks-http`) would be appropriate.
+
+**Location:** Tests could reside in `src/app/api/testimonials/route.test.ts` and `src/app/api/testimonials/[id]/route.test.ts` or a similar structure if using Next.js API routes. If backend logic is in Firebase Functions, tests might be in `functions/src/index.test.ts` or dedicated test files for the testimonial functions.
+
+### `POST /api/testimonials`
+
+*   **Test Case 1.1.1:** Create a new testimonial with valid data.
+    *   **Given:** A request payload with `name` and `text` (and optional `imageUrl`, `designation`).
+    *   **When:** A POST request is made to `/api/testimonials`.
+    *   **Then:** The API should return a `201 Created` status code.
+    *   **And:** The response body should contain the created testimonial, including `id`, `createdAt`, and `updatedAt` fields.
+    *   **And:** The testimonial should be saved in the Firestore database.
+
+*   **Test Case 1.1.2:** Attempt to create a testimonial with missing required fields (name).
+    *   **Given:** A request payload missing the `name` field.
+    *   **When:** A POST request is made to `/api/testimonials`.
+    *   **Then:** The API should return a `400 Bad Request` status code.
+    *   **And:** The response body should contain an error message indicating the missing field.
+
+*   **Test Case 1.1.3:** Attempt to create a testimonial with missing required fields (text).
+    *   **Given:** A request payload missing the `text` field.
+    *   **When:** A POST request is made to `/api/testimonials`.
+    *   **Then:** The API should return a `400 Bad Request` status code.
+    *   **And:** The response body should contain an error message indicating the missing field.
+
+### `GET /api/testimonials`
+
+*   **Test Case 1.2.1:** Fetch all testimonials.
+    *   **Given:** Multiple testimonials exist in the database.
+    *   **When:** A GET request is made to `/api/testimonials`.
+    *   **Then:** The API should return a `200 OK` status code.
+    *   **And:** The response body should be an array of testimonial objects.
+    *   **And:** Testimonials should ideally be ordered (e.g., by `createdAt` descending).
+
+*   **Test Case 1.2.2:** Fetch testimonials when none exist.
+    *   **Given:** No testimonials exist in the database.
+    *   **When:** A GET request is made to `/api/testimonials`.
+    *   **Then:** The API should return a `200 OK` status code.
+    *   **And:** The response body should be an empty array.
+
+### `GET /api/testimonials/[id]` (Endpoint for fetching a single testimonial by ID)
+
+*   **Test Case 1.3.1:** Fetch an existing testimonial by ID.
+    *   **Given:** A testimonial with a specific ID exists.
+    *   **When:** A GET request is made to `/api/testimonials/{id}` with the existing ID.
+    *   **Then:** The API should return a `200 OK` status code.
+    *   **And:** The response body should contain the correct testimonial object.
+
+*   **Test Case 1.3.2:** Attempt to fetch a non-existent testimonial by ID.
+    *   **Given:** A testimonial ID that does not correspond to any entry in the database.
+    *   **When:** A GET request is made to `/api/testimonials/{id}` with the non-existent ID.
+    *   **Then:** The API should return a `404 Not Found` status code.
+
+### `PUT /api/testimonials/[id]`
+
+*   **Test Case 1.4.1:** Update an existing testimonial with valid data.
+    *   **Given:** An existing testimonial and a request payload with updated `name`, `text`, or other fields.
+    *   **When:** A PUT request is made to `/api/testimonials/{id}` with the existing ID and valid data.
+    *   **Then:** The API should return a `200 OK` status code.
+    *   **And:** The response body should contain the updated testimonial object, including an updated `updatedAt` timestamp.
+    *   **And:** The testimonial in the database should reflect the changes.
+
+*   **Test Case 1.4.2:** Attempt to update a testimonial with missing required fields (e.g., empty name).
+    *   **Given:** An existing testimonial and a request payload with an empty `name`.
+    *   **When:** A PUT request is made to `/api/testimonials/{id}`.
+    *   **Then:** The API should return a `400 Bad Request` status code (if validation prevents empty required fields).
+    *   **And:** The response body should contain an error message.
+
+*   **Test Case 1.4.3:** Attempt to update a non-existent testimonial.
+    *   **Given:** A testimonial ID that does not exist and a valid request payload.
+    *   **When:** A PUT request is made to `/api/testimonials/{id}` with the non-existent ID.
+    *   **Then:** The API should return a `404 Not Found` status code.
+
+### `DELETE /api/testimonials/[id]`
+
+*   **Test Case 1.5.1:** Delete an existing testimonial.
+    *   **Given:** An existing testimonial ID.
+    *   **When:** A DELETE request is made to `/api/testimonials/{id}`.
+    *   **Then:** The API should return a `200 OK` status code (or `204 No Content`).
+    *   **And:** The testimonial should be removed from the database.
+
+*   **Test Case 1.5.2:** Attempt to delete a non-existent testimonial.
+    *   **Given:** A testimonial ID that does not exist.
+    *   **When:** A DELETE request is made to `/api/testimonials/{id}`.
+    *   **Then:** The API should return a `404 Not Found` status code.
+
+## 2. Frontend Component Tests
+
+These tests will use a library like React Testing Library with Jest or Vitest. Mocking of API calls (`fetch` or custom data fetching functions) will be necessary.
+
+### `TestimonialCard.tsx`
+
+**Location:** `src/components/TestimonialCard.test.tsx` (or similar, like `src/components/ui/TestimonialCard.test.tsx` if it's considered a generic UI component)
+
+*   **Test Case 2.1.1:** Render testimonial with all details.
+    *   **Given:** A `testimonial` prop with `name`, `text`, `imageUrl`, and `designation`.
+    *   **When:** The `TestimonialCard` component is rendered.
+    *   **Then:** The component should display the name, text, designation, and image (checking for `src` attribute).
+
+*   **Test Case 2.1.2:** Render testimonial with optional fields missing.
+    *   **Given:** A `testimonial` prop with only `name` and `text` (no `imageUrl`, no `designation`).
+    *   **When:** The `TestimonialCard` component is rendered.
+    *   **Then:** The component should display the name and text.
+    *   **And:** It should not render an `<img>` tag if `imageUrl` is missing (or render a placeholder if designed that way).
+    *   **And:** It should not render the designation element if `designation` is missing.
+
+### `TestimonialForm.tsx`
+
+**Location:** `src/components/dashboard/TestimonialForm.test.tsx`
+
+*   **Test Case 2.2.1:** Render all form fields.
+    *   **Given:** The `TestimonialForm` component is rendered (in create mode, no `initialData`).
+    *   **When:** The form is inspected.
+    *   **Then:** Input fields for "Name", "Testimonial Text", "Image URL", and "Designation" should be present.
+    *   **And:** The submit button should say "Add Testimonial" (or similar).
+
+*   **Test Case 2.2.2:** Display validation errors for required fields.
+    *   **Given:** The `TestimonialForm` is rendered.
+    *   **When:** The submit button is clicked without filling in "Name" and "Testimonial Text".
+    *   **Then:** Validation error messages should be displayed for "Name" and "Testimonial Text".
+    *   **And:** The `onSubmit` (mocked API call) function should not have been called.
+
+*   **Test Case 2.2.3:** Submit form with valid data (Create mode).
+    *   **Given:** The `TestimonialForm` is rendered.
+    *   **When:** "Name" and "Testimonial Text" are filled, and the submit button is clicked.
+    *   **Then:** The (mocked) API call function (`fetch` to `POST /api/testimonials`) should be called with the correct form data.
+
+*   **Test Case 2.2.4:** Pre-fill form fields when `initialData` is provided (Edit mode).
+    *   **Given:** The `TestimonialForm` is rendered with `initialData` containing a testimonial's details and `testimonialId`.
+    *   **When:** The form is inspected.
+    *   **Then:** The input fields should be pre-filled with values from `initialData`.
+    *   **And:** The submit button should say "Save Changes" (or similar).
+
+*   **Test Case 2.2.5:** Submit form with valid data (Edit mode).
+    *   **Given:** The `TestimonialForm` is rendered with `initialData` and `testimonialId`.
+    *   **When:** Form fields are (optionally modified and still valid) and the submit button is clicked.
+    *   **Then:** The (mocked) API call function (`fetch` to `PUT /api/testimonials/[id]`) should be called with the correct form data and ID.
+
+### `src/app/dashboard/admin/testimonials/page.tsx` (Admin Testimonials Page)
+
+**Location:** `src/app/dashboard/admin/testimonials/page.test.tsx`
+
+*   **Test Case 2.3.1:** Display table of testimonials on successful fetch.
+    *   **Given:** The page is rendered and the (mocked) API call to fetch testimonials returns a list of items.
+    *   **When:** Data fetching completes.
+    *   **Then:** A table should be displayed with rows corresponding to the fetched testimonials.
+    *   **And:** Columns for `name`, `text`, `createdAt`, `updatedAt` should be visible.
+    *   **And:** "Edit" and "Delete" buttons should be present for each row.
+
+*   **Test Case 2.3.2:** Display loading state.
+    *   **Given:** The page is rendered and the API call is in progress.
+    *   **When:** Data is being fetched.
+    *   **Then:** A loading indicator (e.g., "Loading testimonials...") should be visible.
+
+*   **Test Case 2.3.3:** Display error message on fetch failure.
+    *   **Given:** The page is rendered and the (mocked) API call to fetch testimonials fails.
+    *   **When:** Data fetching fails.
+    *   **Then:** An error message (e.g., "Failed to load testimonials") should be visible.
+
+*   **Test Case 2.3.4:** Display "No testimonials" message.
+    *   **Given:** The page is rendered and the (mocked) API call returns an empty list.
+    *   **When:** Data fetching completes.
+    *   **Then:** A message like "No testimonials found" should be visible.
+
+*   **Test Case 2.3.5:** "Add Testimonial" button navigation.
+    *   **Given:** The page is rendered.
+    *   **When:** The "Add Testimonial" button is clicked.
+    *   **Then:** Navigation to `/dashboard/admin/testimonials/new` should occur (mock `useRouter`).
+
+*   **Test Case 2.3.6:** "Edit" button navigation.
+    *   **Given:** The page is rendered with at least one testimonial.
+    *   **When:** The "Edit" button for a specific testimonial is clicked.
+    *   **Then:** Navigation to `/dashboard/admin/testimonials/edit/[id]` (with the correct ID) should occur.
+
+*   **Test Case 2.3.7:** "Delete" button shows confirmation and calls API.
+    *   **Given:** The page is rendered with at least one testimonial.
+    *   **When:** The "Delete" button for a testimonial is clicked.
+    *   **Then:** A confirmation dialog should appear.
+    *   **When:** The delete action is confirmed in the dialog.
+    *   **Then:** The (mocked) API call to `DELETE /api/testimonials/[id]` should be made with the correct ID.
+    *   **And:** The testimonial row should be removed from the table (optimistic update or re-fetch).
+
+## 3. Homepage Test
+
+**Location:** `src/app/page.test.tsx`
+
+*   **Test Case 3.1.1:** Fetch and display testimonials.
+    *   **Given:** The `HomePage` component is rendered.
+    *   **When:** The (mocked) `getTestimonials` function successfully returns a list of testimonials.
+    *   **Then:** The testimonials section should display `TestimonialCard` components for each fetched testimonial.
+
+*   **Test Case 3.1.2:** Display fallback if no testimonials are fetched.
+    *   **Given:** The `HomePage` component is rendered.
+    *   **When:** The (mocked) `getTestimonials` function returns an empty array or throws an error.
+    *   **Then:** The testimonials section should display a fallback message (e.g., "No testimonials yet. Check back soon!").
+
+This comprehensive list should provide good coverage for the testimonial functionality.

--- a/src/app/api/testimonials/[id]/route.ts
+++ b/src/app/api/testimonials/[id]/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { adminFirestore, FirebaseFirestoreNamespace } from '@/lib/firebaseAdmin';
+import { Testimonial } from '@/types';
+
+// PUT handler to update an existing testimonial
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const { id } = params;
+    if (!id) {
+      return NextResponse.json({ error: 'Testimonial ID is required.' }, { status: 400 });
+    }
+
+    const testimonialData = await request.json();
+    if (Object.keys(testimonialData).length === 0) {
+      return NextResponse.json({ error: 'No data provided for update.' }, { status: 400 });
+    }
+
+    const testimonialRef = adminFirestore.collection('testimonials').doc(id);
+    const doc = await testimonialRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Testimonial not found.' }, { status: 404 });
+    }
+
+    const updateData: Partial<Testimonial> = { ...testimonialData };
+    updateData.updatedAt = FirebaseFirestoreNamespace.Timestamp.now();
+
+    // Remove id from updateData if present, as it should not be changed
+    if (updateData.id) {
+      delete updateData.id;
+    }
+    // Ensure createdAt is not overwritten
+    if (updateData.createdAt) {
+        delete updateData.createdAt;
+    }
+
+
+    await testimonialRef.update(updateData);
+
+    const updatedDoc = await testimonialRef.get();
+    const updatedTestimonial = { id: updatedDoc.id, ...updatedDoc.data() } as Testimonial;
+
+    // Convert Firestore Timestamps to ISO strings for the response
+    if (updatedTestimonial.createdAt && typeof updatedTestimonial.createdAt !== 'string') {
+        updatedTestimonial.createdAt = updatedTestimonial.createdAt.toDate ? updatedTestimonial.createdAt.toDate().toISOString() : new Date(updatedTestimonial.createdAt._seconds * 1000).toISOString();
+    }
+    if (updatedTestimonial.updatedAt && typeof updatedTestimonial.updatedAt !== 'string') {
+        updatedTestimonial.updatedAt = updatedTestimonial.updatedAt.toDate ? updatedTestimonial.updatedAt.toDate().toISOString() : new Date(updatedTestimonial.updatedAt._seconds * 1000).toISOString();
+    }
+
+
+    return NextResponse.json(updatedTestimonial, { status: 200 });
+  } catch (error: any) {
+    console.error(`[api/testimonials/${params.id}] Error updating testimonial:`, error);
+    return NextResponse.json({ error: 'Failed to update testimonial', details: error.message }, { status: 500 });
+  }
+}
+
+// DELETE handler to delete a testimonial
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const { id } = params;
+    if (!id) {
+      return NextResponse.json({ error: 'Testimonial ID is required.' }, { status: 400 });
+    }
+
+    const testimonialRef = adminFirestore.collection('testimonials').doc(id);
+    const doc = await testimonialRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Testimonial not found.' }, { status: 404 });
+    }
+
+    await testimonialRef.delete();
+
+    return NextResponse.json({ message: 'Testimonial deleted successfully.' }, { status: 200 });
+  } catch (error: any) {
+    console.error(`[api/testimonials/${params.id}] Error deleting testimonial:`, error);
+    return NextResponse.json({ error: 'Failed to delete testimonial', details: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { adminFirestore, FirebaseFirestoreNamespace } from '@/lib/firebaseAdmin';
+import { Testimonial } from '@/types';
+
+// GET handler to fetch all testimonials
+export async function GET() {
+  try {
+    const testimonialsRef = adminFirestore.collection('testimonials');
+    const snapshot = await testimonialsRef.orderBy('createdAt', 'desc').get();
+
+    if (snapshot.empty) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    const testimonials: Testimonial[] = [];
+    snapshot.forEach(doc => {
+      const data = doc.data();
+      testimonials.push({
+        id: doc.id,
+        name: data.name,
+        text: data.text,
+        imageUrl: data.imageUrl,
+        designation: data.designation,
+        createdAt: data.createdAt.toDate ? data.createdAt.toDate().toISOString() : new Date(data.createdAt._seconds * 1000).toISOString(),
+        updatedAt: data.updatedAt.toDate ? data.updatedAt.toDate().toISOString() : new Date(data.updatedAt._seconds * 1000).toISOString(),
+      });
+    });
+
+    return NextResponse.json(testimonials, { status: 200 });
+  } catch (error: any) {
+    console.error('[api/testimonials] Error fetching testimonials:', error);
+    return NextResponse.json({ error: 'Failed to fetch testimonials', details: error.message }, { status: 500 });
+  }
+}
+
+// POST handler to create a new testimonial
+export async function POST(request: Request) {
+  try {
+    const testimonialData = await request.json();
+
+    // Basic validation
+    if (!testimonialData.name || !testimonialData.text) {
+      return NextResponse.json({ error: 'Name and text are required fields.' }, { status: 400 });
+    }
+
+    const newTestimonialRef = adminFirestore.collection('testimonials').doc();
+    const now = FirebaseFirestoreNamespace.Timestamp.now();
+
+    const newTestimonial: Omit<Testimonial, 'id'> = {
+      name: testimonialData.name,
+      text: testimonialData.text,
+      imageUrl: testimonialData.imageUrl || null,
+      designation: testimonialData.designation || null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await newTestimonialRef.set(newTestimonial);
+
+    return NextResponse.json({ id: newTestimonialRef.id, ...newTestimonial }, { status: 201 });
+  } catch (error: any) {
+    console.error('[api/testimonials] Error creating testimonial:', error);
+    return NextResponse.json({ error: 'Failed to create testimonial', details: error.message }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/admin/testimonials/edit/[id]/page.tsx
+++ b/src/app/dashboard/admin/testimonials/edit/[id]/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import TestimonialForm from '@/components/dashboard/TestimonialForm';
+import type { Testimonial } from '@/types';
+import { useToast } from '@/hooks/use-toast';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Loader2, AlertTriangle } from 'lucide-react';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb"; // Assuming breadcrumbs exist
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+async function fetchTestimonialById(id: string): Promise<Testimonial | null> {
+  const response = await fetch(`/api/testimonials/${id}`); // Assuming your GET by ID route is set up
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error('Failed to fetch testimonial');
+  }
+  return response.json();
+}
+
+export default function EditTestimonialPage() {
+  const params = useParams();
+  const router = useRouter();
+  const { toast } = useToast();
+  const [testimonial, setTestimonial] = useState<Testimonial | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const id = typeof params.id === 'string' ? params.id : null;
+
+  const loadTestimonial = useCallback(async () => {
+    if (!id) {
+      setError("Testimonial ID is missing.");
+      setIsLoading(false);
+      toast({ title: "Error", description: "No testimonial ID provided.", variant: "destructive" });
+      router.push('/dashboard/admin/testimonials'); // Redirect if no ID
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await fetchTestimonialById(id);
+      if (data) {
+        setTestimonial(data);
+      } else {
+        setError("Testimonial not found.");
+        toast({ title: "Not Found", description: `Testimonial with ID ${id} could not be found.`, variant: "destructive" });
+      }
+    } catch (err: any) {
+      console.error("Error fetching testimonial:", err);
+      setError(err.message || "Failed to load testimonial data.");
+      toast({ title: "Error Loading Data", description: err.message, variant: "destructive" });
+    }
+    setIsLoading(false);
+  }, [id, toast, router]);
+
+  useEffect(() => {
+    loadTestimonial();
+  }, [loadTestimonial]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[300px] space-y-4">
+        <Loader2 className="h-12 w-12 animate-spin text-primary" />
+        <p className="text-muted-foreground">Loading testimonial data...</p>
+      </div>
+    );
+  }
+
+  if (error || !testimonial) {
+    return (
+      <Card className="max-w-lg mx-auto text-center py-12 bg-destructive/10 border-destructive">
+        <CardHeader>
+          <AlertTriangle className="mx-auto h-10 w-10 text-destructive mb-3" />
+          <CardTitle className="text-destructive">
+            {error ? "Error Loading Testimonial" : "Testimonial Not Found"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-destructive/80 mb-6">
+            {error || `Could not find a testimonial with ID: ${id}.`}
+          </p>
+          <Button variant="outline" asChild>
+            <Link href="/dashboard/admin/testimonials">Back to Testimonials List</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/dashboard/admin">Dashboard</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/dashboard/admin/testimonials">Manage Testimonials</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Edit Testimonial</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <TestimonialForm initialData={testimonial} testimonialId={id} />
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/testimonials/new/page.tsx
+++ b/src/app/dashboard/admin/testimonials/new/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import TestimonialForm from '@/components/dashboard/TestimonialForm';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb"; // Assuming breadcrumbs exist
+import Link from 'next/link';
+
+export default function NewTestimonialPage() {
+  return (
+    <div className="space-y-6">
+      {/* Optional: Breadcrumbs for navigation */}
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/dashboard/admin">Dashboard</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/dashboard/admin/testimonials">Manage Testimonials</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Add New Testimonial</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <TestimonialForm />
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/testimonials/page.tsx
+++ b/src/app/dashboard/admin/testimonials/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { FileText, Loader2, Trash2, AlertTriangle, Edit, PlusCircle } from "lucide-react";
+import type { Testimonial } from '@/types';
+import { format } from 'date-fns';
+import { useToast } from '@/hooks/use-toast';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+// Mock functions for now - replace with actual API calls
+async function fetchTestimonialsFromAPI(): Promise<Testimonial[]> {
+  const response = await fetch('/api/testimonials');
+  if (!response.ok) {
+    throw new Error('Failed to fetch testimonials');
+  }
+  return response.json();
+}
+
+async function deleteTestimonialFromAPI(id: string): Promise<void> {
+  const response = await fetch(`/api/testimonials/${id}`, { method: 'DELETE' });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({})); // Catch if response is not JSON
+    throw new Error(errorData.error || 'Failed to delete testimonial');
+  }
+}
+
+export default function AdminManageTestimonialsPage() {
+  const [testimonials, setTestimonials] = useState<Testimonial[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
+  // TODO: Replace with router push or modal for editing/creating
+  // For now, storing ID of testimonial to be deleted
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+
+  const fetchTestimonials = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await fetchTestimonialsFromAPI();
+      setTestimonials(data);
+    } catch (err: any) {
+      console.error("Error fetching testimonials:", err);
+      setError(err.message || "Failed to load testimonials. Please try again.");
+      toast({
+        title: "Error Loading Testimonials",
+        description: err.message || "Could not fetch testimonials.",
+        variant: "destructive"
+      });
+    }
+    setIsLoading(false);
+  }, [toast]);
+
+  useEffect(() => {
+    fetchTestimonials();
+  }, [fetchTestimonials]);
+
+  const handleDeleteTestimonial = async (id: string) => {
+    const originalTestimonials = [...testimonials];
+    const testimonialToDelete = testimonials.find(t => t.id === id);
+    if (!testimonialToDelete) return;
+
+    setTestimonials(prev => prev.filter(t => t.id !== id));
+    setDeletingId(null); // Close dialog
+
+    try {
+      await deleteTestimonialFromAPI(id);
+      toast({
+        title: "Testimonial Deleted",
+        description: `Testimonial by "${testimonialToDelete.name}" has been successfully deleted.`,
+      });
+    } catch (err: any) {
+      console.error("Error deleting testimonial:", err);
+      setTestimonials(originalTestimonials); // Revert UI on error
+      toast({
+        title: "Deletion Failed",
+        description: err.message || "Could not delete the testimonial.",
+        variant: "destructive"
+      });
+    }
+  };
+
+  if (isLoading) {
+    return <div className="flex justify-center items-center h-full"><Loader2 className="h-8 w-8 animate-spin text-primary" /> Loading testimonials...</div>;
+  }
+
+  if (error) {
+    return (
+      <Card className="text-center py-12 bg-destructive/10 border-destructive">
+        <CardHeader>
+          <AlertTriangle className="mx-auto h-10 w-10 text-destructive mb-3" />
+          <CardTitle className="text-destructive">Error Loading Data</CardTitle>
+          <CardDescription className="text-destructive/80">{error}</CardDescription>
+        </CardHeader>
+        <CardContent>
+           <Button onClick={fetchTestimonials} variant="outline">Try Again</Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle className="text-2xl flex items-center">
+            <FileText className="mr-3 h-7 w-7 text-primary" /> Manage Testimonials
+          </CardTitle>
+          <CardDescription>Add, edit, or delete client testimonials.</CardDescription>
+        </div>
+        <Button asChild>
+          {/* TODO: Link to /dashboard/admin/testimonials/new or open modal */}
+          <Link href="/dashboard/admin/testimonials/new">
+            <PlusCircle className="mr-2 h-4 w-4" /> Add Testimonial
+          </Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {testimonials.length === 0 ? (
+          <p className="text-center text-muted-foreground py-8">No testimonials found.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[20%]">Name</TableHead>
+                <TableHead className="w-[40%]">Text</TableHead>
+                <TableHead>Created At</TableHead>
+                <TableHead>Updated At</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {testimonials.map((testimonial) => (
+                <TableRow key={testimonial.id}>
+                  <TableCell className="font-medium">{testimonial.name}</TableCell>
+                  <TableCell className="max-w-md truncate" title={testimonial.text}>{testimonial.text}</TableCell>
+                  <TableCell>{testimonial.createdAt ? format(new Date(testimonial.createdAt), 'PP pp') : 'N/A'}</TableCell>
+                  <TableCell>{testimonial.updatedAt ? format(new Date(testimonial.updatedAt), 'PP pp') : 'N/A'}</TableCell>
+                  <TableCell className="text-right space-x-1">
+                    {/* TODO: Link to /dashboard/admin/testimonials/edit/[id] or open modal */}
+                    <Button variant="ghost" size="sm" asChild title="Edit Testimonial">
+                        <Link href={`/dashboard/admin/testimonials/edit/${testimonial.id}`}>
+                            <Edit className="h-4 w-4" />
+                        </Link>
+                    </Button>
+                    <AlertDialog open={deletingId === testimonial.id} onOpenChange={(open) => !open && setDeletingId(null)}>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive/90 hover:bg-destructive/10" title="Delete Testimonial" onClick={() => setDeletingId(testimonial.id)}>
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This action cannot be undone. This will permanently delete the testimonial by "{testimonial.name}".
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel onClick={() => setDeletingId(null)}>Cancel</AlertDialogCancel>
+                          <AlertDialogAction onClick={() => handleDeleteTestimonial(testimonial.id)} className="bg-destructive hover:bg-destructive/90">
+                            Yes, delete testimonial
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -35,6 +35,7 @@ const navItems: NavItem[] = [
   { href: '/dashboard/admin/coaches', label: 'Manage Coaches', icon: Users, roles: ['admin'] },
   { href: '/dashboard/admin/users', label: 'Manage Users', icon: UserX, roles: ['admin'] }, 
   { href: '/dashboard/admin/blogs', label: 'Manage Blogs', icon: FileText, roles: ['admin'] },
+  { href: '/dashboard/admin/testimonials', label: 'Testimonials', icon: FileText, roles: ['admin'] },
   { href: '/dashboard/admin/messages', label: 'Message Logs', icon: MessageSquare, roles: ['admin'] },
   { href: '/dashboard/admin/settings', label: 'Platform Settings', icon: Settings, roles: ['admin'] },
 ];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,42 +3,16 @@ import { Button } from '@/components/ui/button';
 // import { Input } from '@/components/ui/input'; // Removed Input import
 import { CoachCard } from '@/components/CoachCard';
 import { TestimonialCard } from '@/components/TestimonialCard';
-import type { Testimonial } from '@/types';
-import { getFeaturedCoaches } from '@/lib/firestore';
-import { Search, Users, UserPlus } from 'lucide-react';
-
-// Testimonials are static for now
-const mockTestimonials: Testimonial[] = [
-  {
-    id: '1',
-    name: 'Sarah L.',
-    text: "The Life Coaching Cafe helped me find the perfect life coach who understood my needs. The AI matching was spot on!",
-    imageUrl: 'https://placehold.co/100x100.png',
-    dataAiHint: 'happy person',
-    // designation: 'User of The Life Coaching Cafe',
-  },
-  {
-    id: '2',
-    name: 'John B.',
-    text: "As a coach, registering on The Life Coaching Cafe was easy, and I love the platform's modern design and features for finding clients seeking online life coaching.",
-    imageUrl: 'https://placehold.co/100x100.png',
-    dataAiHint: 'professional person',
-    // designation: 'Life Coach on The Life Coaching Cafe',
-  },
-  {
-    id: '3',
-    name: 'Maria G.',
-    text: "The blog section is full of insightful articles. It's a great resource for anyone interested in personal development and self-coaching techniques.",
-    imageUrl: 'https://placehold.co/100x100.png',
-    dataAiHint: 'thoughtful person',
-    // designation: 'Reader & User',
-  },
-];
+// import type { Testimonial } from '@/types'; // Testimonial type will be inferred from getTestimonials
+import { getFeaturedCoaches, getTestimonials } from '@/lib/firestore';
+import { Search, Users, UserPlus, MessageCircle } from 'lucide-react'; // Added MessageCircle for testimonials icon
 
 
 export default async function HomePage() {
   const featuredCoaches = await getFeaturedCoaches(3);
-  // console.log('Featured Coaches Data (HomePage):', JSON.stringify(featuredCoaches, null, 2)); // Commented out console.log
+  const testimonials = await getTestimonials(3); // Fetch 3 testimonials
+  // console.log('Featured Coaches Data (HomePage):', JSON.stringify(featuredCoaches, null, 2));
+  // console.log('Testimonials Data (HomePage):', JSON.stringify(testimonials, null, 2));
 
  return (
     <div className="space-y-16">
@@ -117,12 +91,19 @@ export default async function HomePage() {
       </section>
       {/* Testimonials Section */}
       <section>
-        <h2 className="text-3xl font-semibold text-center mb-8">What Our Users Say About Finding Their Coach</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {mockTestimonials.map((testimonial) => (
-            <TestimonialCard key={testimonial.id} testimonial={testimonial} />
-          ))}
+        <div className="flex items-center justify-center mb-8">
+          <MessageCircle className="h-8 w-8 text-accent mr-3" />
+          <h2 className="text-3xl font-semibold text-center">What Our Users Say</h2>
         </div>
+        {testimonials.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {testimonials.map((testimonial) => (
+              <TestimonialCard key={testimonial.id} testimonial={testimonial} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-center text-muted-foreground">No testimonials yet. Check back soon!</p>
+        )}
       </section>
       {/* Call to Action Section */}
       <section className="py-12 bg-primary/10 rounded-lg shadow-sm">

--- a/src/components/dashboard/TestimonialForm.tsx
+++ b/src/components/dashboard/TestimonialForm.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Loader2, Save, MessageSquareText, AlertCircle } from 'lucide-react'; // Changed icon
+import { useToast } from '@/hooks/use-toast';
+import { useRouter } from 'next/navigation';
+import type { Testimonial } from '@/types'; // Assuming Testimonial type includes id, name, text, imageUrl, designation, createdAt, updatedAt
+
+const testimonialFormSchema = z.object({
+  name: z.string().min(2, 'Name must be at least 2 characters.').max(100, 'Name must be at most 100 characters.'),
+  text: z.string().min(10, 'Testimonial text must be at least 10 characters.').max(1000, 'Testimonial text must be at most 1000 characters.'),
+  imageUrl: z.string().url('Invalid URL for image.').optional().or(z.literal('')),
+  designation: z.string().max(100, 'Designation must be at most 100 characters.').optional().or(z.literal('')),
+});
+
+type TestimonialFormData = z.infer<typeof testimonialFormSchema>;
+
+interface TestimonialFormProps {
+  initialData?: Testimonial | null; // Make initialData optional for creation
+  testimonialId?: string | null; // To distinguish between create and edit
+  onSave?: () => void; // Optional callback after saving
+}
+
+export default function TestimonialForm({ initialData = null, testimonialId = null, onSave }: TestimonialFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const isEditMode = Boolean(testimonialId && initialData);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+    setValue,
+  } = useForm<TestimonialFormData>({
+    resolver: zodResolver(testimonialFormSchema),
+    defaultValues: {
+      name: initialData?.name || '',
+      text: initialData?.text || '',
+      imageUrl: initialData?.imageUrl || '',
+      designation: initialData?.designation || '',
+    }
+  });
+
+  useEffect(() => {
+    if (initialData) {
+      reset({
+        name: initialData.name,
+        text: initialData.text,
+        imageUrl: initialData.imageUrl || '',
+        designation: initialData.designation || '',
+      });
+    } else {
+      // Reset to empty for create form if no initialData (e.g. navigating directly to 'new' page)
+      reset({ name: '', text: '', imageUrl: '', designation: '' });
+    }
+  }, [initialData, reset]);
+
+  const onSubmit: SubmitHandler<TestimonialFormData> = async (data) => {
+    setIsSubmitting(true);
+    const apiUrl = isEditMode ? `/api/testimonials/${testimonialId}` : '/api/testimonials';
+    const method = isEditMode ? 'PUT' : 'POST';
+
+    try {
+      const response = await fetch(apiUrl, {
+        method: method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ message: 'An unknown error occurred' }));
+        throw new Error(errorData.error || errorData.message || `Failed to ${isEditMode ? 'update' : 'create'} testimonial`);
+      }
+
+      const result = await response.json();
+
+      toast({
+        title: `Testimonial ${isEditMode ? 'Updated' : 'Created'}!`,
+        description: `The testimonial from "${result.name}" has been successfully ${isEditMode ? 'updated' : 'saved'}.`,
+      });
+
+      if (onSave) {
+        onSave();
+      } else {
+        // Default behavior if no onSave callback (e.g. redirect)
+        router.push('/dashboard/admin/testimonials');
+        router.refresh(); // Ensure the list page re-fetches data
+      }
+
+    } catch (error: any) {
+      console.error(`Error ${isEditMode ? 'updating' : 'creating'} testimonial:`, error);
+      toast({
+        title: `${isEditMode ? 'Update' : 'Creation'} Failed`,
+        description: error.message || `Could not ${isEditMode ? 'update' : 'create'} the testimonial. Please try again.`,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card className="shadow-lg">
+      <CardHeader>
+        <CardTitle className="text-2xl flex items-center">
+          <MessageSquareText className="mr-3 h-7 w-7 text-primary" />
+          {isEditMode ? 'Edit Testimonial' : 'Add New Testimonial'}
+        </CardTitle>
+        <CardDescription>
+          {isEditMode ? 'Modify the details of the testimonial below.' : 'Fill in the details to add a new testimonial.'}
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CardContent className="space-y-6 pt-6">
+          <div className="space-y-2">
+            <Label htmlFor="name" className={errors.name ? 'text-destructive' : ''}>Name (Required)</Label>
+            <Input
+              id="name"
+              {...register('name')}
+              placeholder="Client's Full Name"
+              className={errors.name ? 'border-destructive focus-visible:ring-destructive' : ''}
+            />
+            {errors.name && <p className="text-sm text-destructive flex items-center mt-1"><AlertCircle className="h-4 w-4 mr-1" />{errors.name.message}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="text" className={errors.text ? 'text-destructive' : ''}>Testimonial Text (Required)</Label>
+            <Textarea
+              id="text"
+              {...register('text')}
+              rows={5}
+              placeholder="Enter the client's testimonial here..."
+              className={errors.text ? 'border-destructive focus-visible:ring-destructive' : ''}
+            />
+            {errors.text && <p className="text-sm text-destructive flex items-center mt-1"><AlertCircle className="h-4 w-4 mr-1" />{errors.text.message}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="designation">Designation / Company (Optional)</Label>
+            <Input
+              id="designation"
+              {...register('designation')}
+              placeholder="e.g., CEO at Company Inc."
+              className={errors.designation ? 'border-destructive focus-visible:ring-destructive' : ''}
+            />
+            {errors.designation && <p className="text-sm text-destructive flex items-center mt-1"><AlertCircle className="h-4 w-4 mr-1" />{errors.designation.message}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="imageUrl">Image URL (Optional)</Label>
+            <Input
+              id="imageUrl"
+              {...register('imageUrl')}
+              type="url"
+              placeholder="https://example.com/image.png"
+              className={errors.imageUrl ? 'border-destructive focus-visible:ring-destructive' : ''}
+            />
+            {errors.imageUrl && <p className="text-sm text-destructive flex items-center mt-1"><AlertCircle className="h-4 w-4 mr-1" />{errors.imageUrl.message}</p>}
+          </div>
+        </CardContent>
+        <CardFooter className="flex justify-end pt-6 border-t">
+          <Button type="button" variant="outline" onClick={() => router.back()} disabled={isSubmitting} className="mr-2">
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+            {isEditMode ? 'Save Changes' : 'Add Testimonial'}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,8 +110,10 @@ export interface Testimonial {
   name: string;
   text: string;
   imageUrl?: string;
-  dataAiHint?: string;
   designation?: string;
+  createdAt: any; // Firestore Timestamp on server, Date on client after fetch
+  updatedAt: any; // Firestore Timestamp on server, Date on client after fetch
+  dataAiHint?: string;
 }
 
 // For application use (timestamp is ISO string)


### PR DESCRIPTION
This commit introduces a full CRUD functionality for managing testimonials, allowing administrators to add, edit, and delete testimonials displayed on the homepage.

Key changes:

- Added new API endpoints (`/api/testimonials` and `/api/testimonials/[id]`) for managing testimonials in Firestore.
- Created a new section in the admin dashboard (`/dashboard/admin/testimonials`) with a table to display testimonials and forms to add/edit them.
- Updated the homepage to dynamically fetch and display the latest testimonials from the database, replacing the previous hardcoded content.
- Defined the `Testimonial` type and included necessary helper functions for Firestore data handling.
- Created a `TESTING_STRATEGY.md` file outlining test cases for the new functionality.