### PR TITLE
Fix: Use absolute URLs in transactional emails

### DIFF
--- a/src/lib/new_message_template.html
+++ b/src/lib/new_message_template.html
@@ -56,7 +56,7 @@
             <p>Hi {{recipientName}},</p>
             <p>You've received a new message from {{senderName}}. Log in to your account to read it and reply.</p>
             <p style="text-align: center;">
-                <a href="https://www.thelifecoachingcafe.com/dashboard/messages" class="button">View Message</a>
+                <a href="{{dashboardUrl}}" class="button">View Message</a>
             </p>
             <p>Thanks,</p>
             <p>The Life Coaching Cafe Team</p>


### PR DESCRIPTION
Ensures that all links in transactional emails are absolute URLs to prevent them from being broken in email clients.

Changes include:
- Defined a `productionBaseUrl` in `functions/src/index.ts`.
- Updated `onBlogPublished` and `sendBlogEmail` to generate an absolute `postUrl` for the "Blog Post Approved" email.
- Updated `onNewChatMessage` to generate an absolute `dashboardUrl` for the "New Chat Message" email.
- Verified that `src/lib/blog_post_approved_template.html` uses `{{postUrl}}`.
- Updated `src/lib/new_message_template.html` to use `{{dashboardUrl}}` instead of a hardcoded URL.