### PR TITLE
Fix: Correct Stripe API version and improve upgrade UX

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -313,7 +313,7 @@ export const createCheckoutSessionCallable = onCall(
       const userId = request.auth.uid;
 
       const stripe = new Stripe(stripeSecretKey.value(), {
-        apiVersion: "2025-05-28.basil",
+        apiVersion: "2024-04-10",
       });
 
       try {


### PR DESCRIPTION
This commit addresses a regression where your coach upgrade process got stuck on the 'Finalizing your premium upgrade...' message. It also includes prior improvements to the upgrade user experience.

Key changes:
1.  **Corrected Stripe API Version:** Updated the Stripe API version in the `createCheckoutSessionCallable` Firebase Function (in `functions/src/index.ts`) from '2025-05-28.basil' to '2024-04-10'. This is suspected to be the cause of a `payment_intent_unexpected_state` error from Stripe, which prevented the webhook from firing and Firestore from being updated.
2.  **Consolidated Webhook Handling (from previous attempt):** The duplicate Stripe webhook handler `onSubscriptionActivated` in `functions/src/index.ts` remains commented out to ensure the Next.js API route `/api/stripe-webhook` is the sole handler.
3.  **Improved Upgrade UX (from previous attempt):**
    - `src/app/payment-success/page.tsx` now redirects to the coach's profile page with a `?status_update_pending=true` query parameter.
    - `src/app/dashboard/coach/profile/page.tsx` displays a 'Finalizing your premium upgrade...' message if this parameter is present and the subscription tier is not yet 'premium', providing better feedback during potential webhook delays.

These changes aim to resolve the payment processing error with Stripe, ensure reliable Firestore updates via the webhook, and provide a clearer user experience during the upgrade process.