### PR TITLE
Fix: Resolve 'getValues is not defined' in CreateBlogPostPage

### DIFF
--- a/src/app/dashboard/coach/blog/create/page.tsx
+++ b/src/app/dashboard/coach/blog/create/page.tsx
@@ -47,7 +47,8 @@ export default function CreateBlogPostPage() {
     handleSubmit,
     formState: { errors },
     setValue,
-    control // MARKDOWN PREVIEW: Need control for useWatch if used standalone, or just watch from useForm directly
+    control, // MARKDOWN PREVIEW: Need control for useWatch if used standalone, or just watch from useForm directly
+    getValues // Added getValues here
   } = useForm<BlogPostFormData>({
     resolver: zodResolver(blogPostSchema),
     defaultValues: {


### PR DESCRIPTION
The 'getValues' function from react-hook-form was being called in the onClick handlers for the submission buttons without being destructured from the useForm() hook.

This commit adds 'getValues' to the useForm destructuring to make it available in the component's scope, resolving the runtime error that occurred when attempting to save or submit a blog post.