### PR TITLE
Fix: Correct SidebarTrigger children handling for asChild prop

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -261,28 +261,39 @@ Sidebar.displayName = "Sidebar"
 
 const SidebarTrigger = React.forwardRef<
   React.ElementRef<typeof Button>,
-  React.ComponentProps<typeof Button>
->(({ className, onClick, ...props }, ref) => {
-  const { toggleSidebar } = useSidebar()
+  // Adjusted props to make children optional and explicitly include asChild
+  Omit<React.ComponentProps<typeof Button>, 'children'> & { children?: React.ReactNode; asChild?: boolean }
+>(({ className, onClick, children, asChild = false, ...props }, ref) => { // Destructure asChild (default to false) and children
+  const { toggleSidebar } = useSidebar();
 
   return (
-    <Button
+    <Button // This is the Button from @/components/ui/button
       ref={ref}
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
       className={cn("h-7 w-7", className)}
       onClick={(event) => {
-        onClick?.(event)
-        toggleSidebar()
+        onClick?.(event);
+        toggleSidebar();
       }}
-      {...props}
+      asChild={asChild} // Pass the asChild prop to the inner Button
+      {...props} // Spread the remaining props
     >
-      <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      {/*
+        If asChild is true and children are provided to SidebarTrigger,
+        Button (acting as Slot) will use those children.
+        Otherwise, render the default PanelLeft icon and span.
+      */}
+      {asChild && children ? children : (
+        <>
+          <PanelLeft />
+          <span className="sr-only">Toggle Sidebar</span>
+        </>
+      )}
     </Button>
-  )
-})
+  );
+});
 SidebarTrigger.displayName = "SidebarTrigger"
 
 const SidebarRail = React.forwardRef<


### PR DESCRIPTION
Resolves a "React.Children.only expected to receive a single React element child" error that occurred when using SidebarTrigger with the asChild prop in the dashboard layout.

The SidebarTrigger component was updated to explicitly manage its children based on the asChild prop:
- If asChild is true and children are provided to SidebarTrigger, these children are rendered (allowing the internal Button to act as a Slot and clone props onto the provided child).
- Otherwise (if asChild is false, or true but no children are provided), SidebarTrigger renders its default content (the PanelLeft icon and a screen-reader span).

This change ensures that the underlying Slot component receives a single, valid React child when asChild is utilized, preventing the runtime error and allowing correct rendering of custom trigger elements, such as the Menu icon button used in the mobile dashboard view.