### PR TITLE
Fix: Correct dashboard layout on desktop and mobile

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -79,9 +79,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   return (
     <SidebarProvider>
-      <div className="flex min-h-[calc(100vh-theme(spacing.16)-theme(spacing.16)-2px)]">
+      <div className="flex mt-16 min-h-[calc(100vh-theme(spacing.16)-theme(spacing.16)-2px)]">
         {/* Mobile Sidebar Trigger */}
-        <div className="md:hidden fixed top-4 left-4 z-50">
+        <div className="md:hidden fixed top-20 left-4 z-50">
           <SidebarTrigger asChild>
             <Button variant="outline" size="icon" className="shadow-lg">
               <Menu className="h-6 w-6" />


### PR DESCRIPTION
Addresses layout problems in the dashboard where:
1. Desktop: The sidebar was positioned too high (underneath the global site logo) and main content elements were misaligned or overflowing.
2. Mobile: The dashboard's sidebar trigger button was overlapping the site logo.

Changes made:
- In `src/app/dashboard/layout.tsx`:
  - Added `mt-16` to the main flex container that wraps the Sidebar and main content area. This pushes the entire dashboard layout down by the height of the sticky global header (16 units = 64px), correctly positioning it in the viewport. This resolves the desktop sidebar positioning and the consequential misalignment of main content elements.
  - Modified the fixed positioning of the mobile `SidebarTrigger` wrapper from `top-4` to `top-20`. This moves the trigger button down to appear below the global header, preventing it from covering the logo.

These changes ensure the dashboard layout is correctly displayed relative to the global site header on both desktop and mobile views.