### PR TITLE
Fix: Resolve 404 error when editing new blog post drafts

### DIFF
--- a/src/app/dashboard/coach/blog/edit/[postId]/page.tsx
+++ b/src/app/dashboard/coach/blog/edit/[postId]/page.tsx
@@ -5,14 +5,6 @@ import type { BlogPost } from '@/types';
 import { notFound } from 'next/navigation';
 import { currentUser } from '@/lib/auth'; // For server-side auth check if needed
 
-export async function generateStaticParams() {
-  // Assuming mockBlogPosts contains all possible blog posts for static generation
-  // In a real app, you might fetch only your own posts or a subset
-  return mockBlogPosts.map((post) => ({
-    postId: post.id,
-  }));
-}
-
 interface PageProps {
   params: { postId: string };
 }


### PR DESCRIPTION
The page `src/app/dashboard/coach/blog/edit/[postId]/page.tsx` used `generateStaticParams` with mock data. This caused 404 errors for newly created blog posts whose IDs were not present in the mock data at build time.

This commit removes the `generateStaticParams` function from this page to allow dynamic server-side rendering for any `postId`. This ensures that newly created drafts can be accessed and edited without encountering a 404 error.