### PR TITLE
Fix: Resolve desktop and mobile dashboard layout issues

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -81,9 +81,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     <SidebarProvider>
       <div className="flex mt-16 min-h-[calc(100vh-theme(spacing.16)-theme(spacing.16)-2px)]">
         {/* Mobile Sidebar Trigger */}
-        <div className="md:hidden fixed top-20 left-4 z-50">
+        <div className="md:hidden fixed top-28 left-4 z-50">
           <SidebarTrigger asChild>
-            <Button variant="outline" size="icon" className="shadow-lg">
+            <Button size="icon" className="shadow-lg bg-green-500 hover:bg-green-600 text-white focus-visible:ring-green-400">
               <Menu className="h-6 w-6" />
             </Button>
           </SidebarTrigger>
@@ -115,7 +115,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           </SidebarContent>
         </Sidebar>
 
-        <main className="flex-1 p-6 md:ml-64">
+        <main className="flex-1 p-6 md:ml-64 min-w-0">
           {children}
         </main>
       </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -224,7 +224,7 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            "duration-200 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear",
+            "duration-200 relative h-full w-[--sidebar-width] bg-transparent transition-[width] ease-linear",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
@@ -234,7 +234,7 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex",
+            "duration-200 sticky top-0 z-10 hidden h-full w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",


### PR DESCRIPTION
This commit addresses several layout problems in the dashboard:

Desktop:
1.  The main sidebar was incorrectly positioned at the top of the viewport, overlapping the global site header. This was due to `fixed inset-y-0` styling on the sidebar component.
    - Changed the sidebar component in `src/components/ui/sidebar.tsx` to use `sticky top-0 h-full` for its desktop view. This makes it stick to the top of its parent container in `DashboardLayout`, which is correctly offset below the global header by `mt-16`.
    - Adjusted the sidebar's "gap" div height to `h-full` to match.
2.  Main content elements were shifted right and overflowing.
    - This was likely a consequence of the sidebar's incorrect fixed positioning. With the sidebar now sticky and in the correct flow, and `min-w-0` added to the `<main>` tag in `src/app/dashboard/layout.tsx`, content alignment should be restored.

Mobile:
1.  The dashboard's sidebar trigger (burger icon) was still overlapping the site logo.
    - Adjusted the `fixed` positioning of the trigger's wrapper div in `src/app/dashboard/layout.tsx` from `top-20` to `top-28` to ensure it clears the logo.
2.  The mobile trigger button needed to be visually distinct.
    - Changed the `Button` component for the trigger to have a green background (`bg-green-500`) and white text, removing the `variant="outline"` to ensure a solid color.

These changes collectively improve the dashboard's visual consistency and usability across desktop and mobile devices.